### PR TITLE
build/release: automatically set addon version number from release git tag

### DIFF
--- a/.github/workflows/package_release.yml
+++ b/.github/workflows/package_release.yml
@@ -12,7 +12,11 @@ jobs:
     - name: Get tag
       id: release_tag
       run: echo ::set-output name=TAG::"${GITHUB_REF/refs\/tags\//wowbject_}.zip"
-    - uses: actions/checkout@master
+    - name: checkout repo
+      uses: actions/checkout@master
+    - name: Update version number
+      id: ver_update
+      run: bash ./setver.sh ${GITHUB_REF/refs\/tags\//}
     - name: Move contents to subdir
       id: move_files
       run: mkdir .wowbject && mv * .wowbject && mv .wowbject wowbject

--- a/__init__.py
+++ b/__init__.py
@@ -25,7 +25,7 @@ bl_info = {
     "author" : "Asher and Alinsa",
     "description" : "Import World of Warcraft objects as correctly as possible",
     "blender" : (2, 90, 0),
-    "version" : (1, 0, 1),
+    "version" : (0, 0, 0),   # autoreplace
     "location" : "File > Import",
     "wiki_url": "https://github.com/ThatAsherGuy/WoWbjectImporter",
     "category" : "Import-Export"

--- a/setver.sh
+++ b/setver.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Replace our addon version string in __init__.py with the one specified by
+# the git tag we've been passed. There's probably an action to do this, but
+# I sure couldn't find it. Kinda ugly, but it'll work.
+
+if [ -z "$1" ]; then
+    echo "usage: $0 <tag>"
+    exit 1
+fi
+
+echo tag: $1
+tag=$1
+
+if ! echo $tag | grep -E -q '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+    echo "error: version tag must be in the form of 'v1.2.3'"
+    exit 2
+fi
+
+verstring=$(echo $tag | sed -E 's/^v([0-9]+)\.([0-9]+)\.([0-9]+)$/\1, \2, \3/')
+
+# sanity check -- make sure our string to be replaced is in the file
+if ! grep -E -q '^[ ]+\"version\".*0, 0, 0.*# autoreplace' __init__.py; then
+    echo "error: replacement string placeholder not found in __init__.py"
+    exit 3
+fi
+
+# this command sucks
+sed -E "s/^([ ]+)\"version\".* # autoreplace.*$/\1\"version\": ( ${verstring} ),  # autoreplace/" < __init__.py > ver.tmp
+
+
+# sanity check -- make sure the original string is missing now
+if grep -E -q '^[ ]+\"version\".*0, 0, 0.*# autoreplace' ver.tmp; then
+    echo "error: still found original replacement placeholder in __init__.py"
+    rm -f ver.tmp
+    exit 3
+fi
+
+mv ver.tmp __init__.py


### PR DESCRIPTION
A bit ugly, but it should work (or at least explode without doing damage if there's problems) any time a tag is made on the main branch w/ a format of `v1.2.3`.  Make sure to keep the version line in the committed `__init__.py` the same as it is now so the script can find it and do good things.