### PR TITLE
tests: add multi-image test support for big areas and such

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -24,7 +24,7 @@ Two main tests currently:
 
 There are four main subdirectories:
 
-* *test_data:*  The "input" test data. This directory consists of data exported from wow.export. There is a lot of data here. You'll need to get a copy of this from Alinsa, since there's no way to do an automated export from wow.export
+* *test_data:*  The "input" test data. This directory consists of data exported from wow.export. There is a lot of data here. There is a `syncdata.sh` script in the tests directory that will download the data from Alinsa, since there's no way to do an automated export from wow.export. You will need `rsync` installed somewhere in your path.
 * *render_references:* The corpus of "correct" renders for testing against. You can create your own by running the normal render test, and then `cp render_results/* render_references/`, if you think your current output is correct (i.e. prior to refactoring), or ask Alinsa for a copy of hers. Note that reference images created on a different computer may not be pixel-for-pixel identical to renders created locally, even if the render is correct
 * *render_results:* The output images from the `test_render` check. These are what the current version of the code WoWbject code is producing
 * *render_diffs:* When there are differences between the render_references and render_results images for a test, an image is written here, with the differing pixels highlighted in red. Ideally the diff would actually be an xor of the two images (which would just be 100% black for no differences), but GraphicsMagick doesn't support that(!?)
@@ -36,6 +36,16 @@ In addition, there is:
 
 ## Running
 
-Make sure you're in the `tests` directory, and run `pytest`. That's basically it.
+Make sure you're in the `tests` directory, and run `pytest`. That's basically it. The full test suite takes a while. Sorry.
 
-You can run a subset of tests with `pytest -k <string>`, where only tests matching `<string>` will be run.
+You can run a subset of tests by requesting certain tests via markers or by name. You can get a complete list of markers via `pytest --markers`, but the WoWbject-specific markers are:
+
+* **m2:** Tests that work with m2 files
+* **wmo:** Tests that work with wmo files
+* **top10:** Run the "top 10" tests of each category, for quick testing. (The "top" tests are generally for the shaders that are used in the highest number of models)
+* **top10m2** and **top10wmo**: The "top 10" tests for these specific categories
+* **fancy:** Tests that render cool-looking things, meant to test nothing but the user's eyeballs (if these things don't look cool to you, please validate your eyeballs)
+* **bug:** Validation for known bugs/problems; tests are named after the github issue they track
+* **superfast:** Intended as an extremely fast test suite to verify very basic functionality, (super)fast
+
+You can further (or alternately) run a subset of tests with `pytest -k <string>`, where only tests matching `<string>` will be run. When combined, only tests matching *both* of the `-m` and `-k` arguments will be run.

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -16,13 +16,25 @@ abspath = os.path.abspath(__file__)
 dname = os.path.dirname(abspath)
 os.chdir(dname)
 
+def mktestid(category, subcategory, test_name):
+    """make id for a test based on category, (optional) subcategory, and test name"""
+    if subcategory is None or len(subcategory) == 0:
+        return str.join("_", [category, test_name])
+    else:
+        return str.join("_", [category, subcategory, test_name])
+
+
+# Just gives us the name of the blender executable, which is configurable
+# with the --blender-exe command line option
 @pytest.fixture()
 def blender_exe(pytestconfig):
+    """Gives the name of the blender executable (set w/ --blender-exe)"""
     return pytestconfig.getoption("blender_executable")
 
 
 @pytest.mark.tryfirst
 def test_blender_exe(blender_exe):
+    """Test to verify that blender works, before running tests depending on it"""
     success, failmsg = run_blender_python(
         "wowbject_render.py",
         ["--ping"],
@@ -34,8 +46,9 @@ def test_blender_exe(blender_exe):
         pytest.exit(f"couldn't exec blender with executable '{blender_exe}'")
 
 
-def run_blender_python(scriptpath: str, scriptargs: List[str], timeout: int = 60, blender_exe: str = "blender"):
-    # blender_bin = "blender"
+def run_blender_python(scriptpath: str, scriptargs: List[str],
+                       timeout: int = 60, blender_exe: str = "blender"):
+    """Run a python script with blender, with optional script arguments"""
     blender_args = [
         blender_exe,
         "--background",
@@ -53,35 +66,36 @@ def run_blender_python(scriptpath: str, scriptargs: List[str], timeout: int = 60
     failmsg = None
 
     try:
-        # subprocess.run(blender_args, stdin=stdin, stdout=testlog,
-        #                stderr=testlog, timeout=timeout, check=True)
-        subprocess.run(blender_args, stdin=None,
-                       timeout=timeout, check=True)
+        subprocess.run(blender_args, stdin=None, timeout=timeout, check=True)
 
     except (subprocess.CalledProcessError) as e:
-        # If I don"t raise a new exception from None, pytest tries to show us
-        # the origin of the error inside the subprocess module, and that"s
-        # pretty useless.
         t = type(e).__name__
-        # raise Exception(f"blender import/rendering failed ({t})") from None
+
         success = False
         failmsg = f"blender import/rendering failed ({t})"
 
     except (OSError) as e:
         t = type(e).__name__
-        # raise Exception(f"error executing blender: {t} - {e}") from None
+
         success = False
         failmsg = f"error executing blender: {t} - {e}"
 
-    # assert success, failmsg
-    #
-    # FIXME: This apparently doesn't work? Things that render but don't
-    # compare ok still return the blender output?
-    # capsys.readouterr()
 
     return success, failmsg
 
 
+# FIXME: Use PIL here instead, maybe?
+#
+# output format being parsed:
+#
+#   Image Difference(MeanAbsoluteError):
+#              Normalized    Absolute
+#             ============  ==========
+#        Red: 0.0509441923     3338.6
+#      Green: 0.0482937613     3164.9
+#       Blue: 0.0434155269     2845.2
+#    Opacity: 0.0000000000        0.0
+#      Total: 0.0356633701     2337.2
 compare_re = re.compile(r"""
     \s*
     (?P<field>Red|Green|Blue|Opacity|Total):
@@ -92,6 +106,7 @@ compare_re = re.compile(r"""
 """, re.VERBOSE)
 
 def parse_gm_compare(output: str):
+    """Parse the output of 'gm compare' and return a map with the values"""
     ret = {}
     for line in output.split("\n"):
         m = compare_re.search(line)
@@ -108,7 +123,9 @@ def parse_gm_compare(output: str):
     return ret
 
 
-def compare_images(refimg: str, checkimg: str, diffimg: str = None, threshold: float = 0.0, timeout: int = 10):
+def compare_images(refimg: str, checkimg: str, diffimg: str = None,
+                   threshold: float = 0.0, timeout: int = 10):
+    """Compare two images for similarity and assert based on a threshold"""
     gm_bin = "gm"
     gm_args = [
         gm_bin,
@@ -168,60 +185,105 @@ marklist = {
     "knownfail": pytest.mark.xfail(reason="Known currently broken", run=False)
 }
 
+
+# I'm not exactly thrilled with how multi-image tests are set up, but here's
+# at least a defense of why it is as it is...   --A
+#
+# So, there are times we want to do tests of things, where we want to render
+# multiple images from the same import. Right now, "import obj + render scene +
+# compare image" is a single pair of pytest steps (one for import + render, one
+# for compare). If we wanted to have a separate pair of tests for every
+# individual image in a set of N, we would have to import the scene N separate
+# times, which isn't so bad for small imports, but sucks for something like,
+# say, Stormwind. And since there's not really a way (currently) to have
+# separate tests that all work off the same blender instance, that's our
+# only choie if we want separate tests. That sucks.
+#
+# So, instead, we need to make things so that one 'test' can render multiple
+# images, and compares all of them. This sucks because only the entire test
+# will end up failing (or not), but it's the best I can figure out right now,
+# without having the test suite run entirely within Blender (which is damned
+# tempting, tbh)
+#
+# The way this ends up working is if a test in the CSV has no category but
+# has a camera location specified for it, the camera info will be added to
+# the camera info for the previous test (etc), and passed as a list to all
+# the various code. And then the various code has special cases for outputting
+# and checking the whatever_imgXX.png results. It'll do, but man some of the
+# special-case code makes things long-winded in places.
 def tlist(category=None):
-    marked_tests = []
+    """Generate a list of image-generation tests and associated parameters"""
+    tests = []
     with open("testlist.csv", newline="") as csvfile:
         reader = csv.DictReader(csvfile, dialect='excel')
 
         for test in reader:
-            if not test["category"]:
+            # no category && no camera location == no test on this line
+            if not test["category"] and not test["cameraloc"]:
                 continue
 
+            # no category && yes cameraloc == multi-image test
+            if not test["category"]:
+                prev = tests[-1]
+
+                # Convert camera loc & rot to lists if they're not
+                if not isinstance(prev["cameraloc"], list):
+                    prev["cameraloc"] = [prev["cameraloc"]]
+                if not isinstance(prev["camerarot"], list):
+                    prev["camerarot"] = [prev["camerarot"]]
+
+                # FIXME: should probably check to make sure both fields set
+                prev["cameraloc"].append(test["cameraloc"])
+                prev["camerarot"].append(test["camerarot"])
+
+                # We're just adjusting an existing test, no need to do more
+                # processing, just go to next line
+                continue
+
+            tests.append(test)
+
+        # We have all our tests (and multi-image subtests), add marks
+        marked_tests = []
+
+        for test in tests:
             marks = []
+
+            # set marks based on categories, where those marks exist
             cat = test["category"]
             if cat in marklist:
                 marks.append(marklist[cat])
 
+            # set marks based on explicit "marks" column of CSV
             m = test["marks"].split(",")
-
             if len(m) > 0:
                 for mark in m:
                     if mark in marklist:
                         marks.append(marklist[mark])
 
-            marked_tests.append(pytest.param(test, marks=marks))
-        # if category:
-        #     tests = [v for v in reader if v["category"] == category]
-        # else:
-        #     tests = [v for v in reader]
+            # generate an id for the test
+            id = mktestid(test['category'], test['subcategory'],
+                          test['test_name'])
 
-    # marked_tests=[]
-    # for test in tests:
-    #     marks = []
-    #     if test["category"]
-    #     if test["category"] == "m2":
-    #         marked_tests.append(pytest.param(test, marks=pytest.mark.m2))
-    #     elif test["category"] == "wmo":
-    #         marked_tests.append(pytest.param(test, marks=pytest.mark.wmo))
+            # done with this test, add it to the list and move on
+            marked_tests.append(pytest.param(test, marks=marks, id=id))
 
     return marked_tests
 
 
+# t_render is automatically run as a fixture, with its return value being
+# a named tuple with 'success' and 'failure message' fields. All the work
+# for this test is done in that fixture, with the test itself just checking
+# for success.
 def test_render(t_render):
-    r = t_render.param
+    """Validate a test render happens without error"""
     success = t_render.success
 
     assert success, t_render.failmsg
 
 
-def test_render_check(request, t_render):
-    r = t_render.param
-    fn = mkname(r['category'], r['subcategory'], r['test_name'])
-
-    refimg = os.path.join("render_references", f"{fn}.png")
-    checkimg = os.path.join("render_results", f"{fn}.png")
-    diffimg = os.path.join("render_diffs", f"{fn}.png")
-
+def checkimage(refimg, checkimg, diffimg, threshold=0.00001):
+    """Verify we have a reference image and compare to test render"""
+    # FIXME: verify this skips correctly from a subroutine
     if not os.path.exists(refimg):
         pytest.skip(f"no image {refimg}")
 
@@ -229,68 +291,88 @@ def test_render_check(request, t_render):
         pytest.skip(f"no image {checkimg}")
 
     compare_images(refimg=refimg, checkimg=checkimg, diffimg=diffimg,
-                   threshold=0.00001)
+                   threshold=threshold)
 
 
-def mkname(category, subcategory, test_name):
-    if subcategory is None or len(subcategory) == 0:
-        return str.join("_", [category, test_name])
+def test_render_check(request, t_render):
+    "Verify the result of a test render looks like it's expected to look"
+    r = t_render.param
+    id = mktestid(r['category'], r['subcategory'], r['test_name'])
+
+    if isinstance(r["cameraloc"], list):
+        fn = f"{id}_img%02d.png"
+        # cameraloc = ",".join(r["cameraloc"])
+        # camerarot = ",".join(r["camerarot"])
+        # outimg = os.path.join("render_results", f"{fn}_img%02d.png")
+
+        for i in range(1, len(r["cameraloc"]) + 1):
+            refimg = os.path.join("render_references", fn % (i))
+            checkimg = os.path.join("render_results", fn % (i))
+            diffimg = os.path.join("render_diffs", fn % (i))
+
+            checkimage(refimg, checkimg, diffimg)
     else:
-        return str.join("_", [category, subcategory, test_name])
+        refimg = os.path.join("render_references", f"{id}.png")
+        checkimg = os.path.join("render_results", f"{id}.png")
+        diffimg = os.path.join("render_diffs", f"{id}.png")
 
+        checkimage(refimg, checkimg, diffimg)
 
-def idfn(fv):
-    return mkname(fv['category'], fv['subcategory'], fv['test_name'])
-
-
-# @pytest.fixture(params=tlist(), ids=idfn)
-# def t_render(request):
-#     r = request.param
-
-#     fn = str.join("_", [r['category'], r['subcategory'], r['test_name']])
-#     obj = r["obj_file"].replace(posixpath.sep, os.sep)
-#     run_blender_python(
-#         "wowbject_render.py",
-#         [
-#             "-o", os.path.join("render_results", f"{fn}.png"),
-#             os.path.join("test_data", obj),
-#         ]
-#     )
-
-#     compare_renders(os.path.join("render_references", f"{fn}.png"),
-#                     os.path.join("render_results", f"{fn}.png"),
-#                     os.path.join("render_diffs", f"{fn}.png"))
 
 RenderReturn = collections.namedtuple(
     "RenderReturn", ["param", "success", "failmsg"])
 
-@pytest.fixture(params=tlist(), ids=idfn)
+@pytest.fixture(params=tlist())
 def t_render(request, capsys):
+    """test fixture that performs a test render on a test from our test list"""
     r = request.param
 
-    fn = mkname(r['category'], r['subcategory'], r['test_name'])
-    outimg = os.path.join("render_results", f"{fn}.png")
-
-    if os.path.exists(outimg):
-        os.remove(outimg)
-
+    # normalize our input file path, and make sure it exists
     objdata = os.path.join(
         "test_data", r["obj_file"].replace(posixpath.sep, os.sep))
     assert os.path.exists(objdata), f"no source file '{objdata}'"
 
+    id = mktestid(r['category'], r['subcategory'], r['test_name'])
+
+    # if we have multiple cameras, generate a "template" output filename and
+    # a list of camera parameters, otherwise just use a straight output
+    # filename and normal camera params.
+    #
+    # Also, remove any existing output images of the same names, first, so
+    # that we don't end up accidentally comparing against the wrong image if
+    # something goes wrong and doesn't get caught at this stage.
+    if isinstance(r["cameraloc"], list):
+        cameraloc = ",".join(r["cameraloc"])
+        camerarot = ",".join(r["camerarot"])
+        outimg = os.path.join("render_results", f"{id}_img%02d.png")
+
+        for i in range(1, len(r["cameraloc"]) + 1):
+            checkfn = outimg % (i)
+            if os.path.exists(checkfn):
+                os.remove(checkfn)
+
+    else:
+        cameraloc = r["cameraloc"]
+        camerarot = r["camerarot"]
+        outimg = os.path.join("render_results", f"{id}.png")
+
+        if os.path.exists(outimg):
+            os.remove(outimg)
+
+
+    # Call the render script w/ blender + our arguments
     success, failmsg = run_blender_python(
         "wowbject_render.py",
         [
-            "--cameraloc", r["cameraloc"], "--camerarot", r["camerarot"],
+            "--cameraloc", cameraloc, "--camerarot", camerarot,
             "-o", outimg, objdata,
         ]
     )
 
     # This clears stdout/stderr captures, so that we don't get the blender
     # output if something fails further along (is there a better way to
-    # do this?)
+    # do this? (does this even work?)
     if success:
         capsys.readouterr()
 
-    # just give the whole test blob back
     return RenderReturn(r, success, failmsg)

--- a/tests/testlist.csv
+++ b/tests/testlist.csv
@@ -159,7 +159,8 @@ wmo,,shader_0,world/wmo/darkmoonfaire/darkmoon_blockringtoss01.obj,575758,front,
 wmo,,shader_1,world/wmo/brokenisles/eredar/7er_cliffbuilding01_nobase.obj,1621771,left,default,"top10,top10wmo",,515,Specular,
 wmo,,shader_2,world/wmo/brokenisles/eredar/7er_colosseum.obj,1572503,default,default,skip,,168,Metal,"""ring"" group only, tower bits"
 ,,shader_3,,,,,,,367,Env,
-wmo,,shader_4,world/wmo/darkmoonfaire/8df_darkmoon_rollercoaster.obj,2339687,"(6.85,-60.73,71.63)","(82.4,0,23.6)","top10,top10wmo",,20803,Opaque,sun flames in particular
+wmo,,shader_4,world/wmo/darkmoonfaire/8df_darkmoon_rollercoaster.obj,2339687,default,default,"top10,top10wmo",,20803,Opaque,sun flames in particular
+,,,,,"(6.85,-60.73,71.63)","(82.4,0,23.6)",,,,,
 ,,shader_5,,,,,"top10,top10wmo",,6833,EnvMetal,
 ,,shader_6,,,,,"top10,top10wmo",,1898,TwoLayerDiffuse,
 ,,shader_7,,,,,"top10,top10wmo",,6297,TwoLayerEnvMetal,
@@ -186,3 +187,4 @@ bug,,GH-12,creature/madscientist2/madscientist2.obj,3515267,,,,norender,,,
 bug,,GH-13,creature/faeriedragon/faeriedragon.obj,123816,,,,norender,,,
 bug,,GH-14,character/troll/female/trollfemale_hd_sdr.obj,1838588,,,,norender,,,
 bug,,GH-16,world/wmo/brokenisles/eredar/7er_colosseum.obj,1572503,,,,,,partial exports broken,
+,,,,,,,,,,,

--- a/tests/wowbject_render.py
+++ b/tests/wowbject_render.py
@@ -5,6 +5,7 @@ import math
 import os
 import re
 import sys
+import time
 from typing import *
 
 import bpy
@@ -14,22 +15,50 @@ sys.path.append(os.getcwd())
 from testutil import util
 
 
-locrot_re = re.compile(r"""
-^\s*
-(?P<degrad>d|r)?
-\(\s*
-    (?P<x> -?[\d.]+)
-    \s*,\s*
-    (?P<y> -?[\d.]+)
-    \s*,\s*
-    (?P<z> -?[\d.]+)
-    \s*
-\)\s*$
+def now() -> float:
+    """Return the current time, in epoch time, as a float"""
+    return float(time.time())
+
+
+def camera_reset(camera: bpy.types.Camera):
+    """Reset the camera to a fixed position and rotation"""
+    camera.rotation_euler = Euler((0.0, 0.0, 0.0), 'XYZ')
+    camera.location.x = 0.0
+    camera.location.y = 0.0
+    camera.location.z = 0.0
+
+
+# Types of 'simple' camera placement currently implemented
+camera_loc_types = ["default", "front", "left"]
+
+locseries_re = re.compile(r"""
+# Either of the following
+(
+    # location or rotation, keywords
+    (?P<keyword>default|front|left|right|back|top|bottom)
+
+|   # or
+
+    # location or rotation, xyz
+    (?P<degrad>d|r)?
+    \(\s*
+        (?P<x> -?[\d.]+)
+        \s*,\s*
+        (?P<y> -?[\d.]+)
+        \s*,\s*
+        (?P<z> -?[\d.]+)
+        \s*
+    \)
+)
+[\s,]*
 """, re.VERBOSE)
 
-camera_loc_types = ["", "default", "front", "left"]
 
-def cameraprep_simple(camera: bpy.types.Camera, loc: str) -> None:
+def camera_set_position_simple(camera: bpy.types.Camera, loc: str) -> None:
+    """Position a camera in a 'simple' automatic way useful on many models"""
+    if loc not in camera_loc_types:
+        raise ValueError(f"unimplemented camera location type '{loc}' specified")
+
     if loc == "front":
         camera.rotation_euler = Euler(
             (math.radians(75), 0, math.radians(75)), 'XYZ')
@@ -40,34 +69,40 @@ def cameraprep_simple(camera: bpy.types.Camera, loc: str) -> None:
         camera.rotation_euler = Euler(
             (math.radians(-90), math.radians(-145), math.radians(0)), 'XYZ')
 
+    # Stupid trick -- have it do the camera_view_to_selected with  a slightly
+    # zoomed lens, then zoom it out to what we really want to be at, and we
+    # get a little buffer on the edges of the image
+    #
+    # FIXME: We might want to do this less for a larger model. Needs study.
+    camera.data.lens = camera.data.lens + 2
     bpy.ops.view3d.camera_to_view_selected()
+    camera.data.lens = camera.data.lens - 2
 
 
-def cameraprep(camera: bpy.types.Camera, loc: str, rot: str) -> None:
-    # one of our special cases?
-    if loc in camera_loc_types:
-        return cameraprep_simple(camera, loc)
+# FIXME: Accepting regex match objects is FUGLY
+def camera_set_position(camera: bpy.types.Camera, loc: re.Match, rot: re.Match) -> None:
+    """Set camera position and rotation"""
 
-    # not special, so do the full thing
-    m = locrot_re.match(loc)
-    if not m or m.group("degrad") is not None:
-        raise ValueError(f"invalid location string: {loc}")
+    # is this one of our 'simple' cases?
+    if loc.group("keyword"):
+        return camera_set_position_simple(camera, loc.group("keyword"))
 
-    camera.location.x = float(m.group("x"))
-    camera.location.y = float(m.group("y"))
-    camera.location.z = float(m.group("z"))
+    # not a 'simple' case, so do the full thing, location first
+    if loc.group("degrad") is not None:
+        raise ValueError(
+            f"invalid location string (includes degrees/radian specifier")
 
+    camera.location.x = float(loc.group("x"))
+    camera.location.y = float(loc.group("y"))
+    camera.location.z = float(loc.group("z"))
 
-    m = locrot_re.match(rot)
-    if not m:
-        raise ValueError(f"invalid rotation string: {rot}")
-    if m:
-        x = float(m.group("x"))
-        y = float(m.group("y"))
-        z = float(m.group("z"))
+    # and then the rotation
+    x = float(rot.group("x"))
+    y = float(rot.group("y"))
+    z = float(rot.group("z"))
 
     # convert to radians if we're not already there
-    if m.group("degrad") != "r":
+    if rot.group("degrad") != "r":
         x = math.radians(x)
         y = math.radians(y)
         z = math.radians(z)
@@ -75,58 +110,89 @@ def cameraprep(camera: bpy.types.Camera, loc: str, rot: str) -> None:
     camera.rotation_euler = Euler((x, y, z), 'XYZ')
 
 
-def sceneprep(args) -> None:
-    # bpy.ops.object.light_add(type='SUN', radius=1, align='WORLD',
-    #                          location=(0, 0, 0), scale=(1, 1, 1))
+def camera_prep(_args, cameraloc, camerarot) -> bpy.types.Camera:
+    """Create camera if needed, reset it, and set its location/rotation"""
 
-    bpy.ops.object.select_all(action='SELECT')
+    # retrieve the existing camera or make a new one
+    # FIXME: This should probably store an id and not the actual camera,
+    # otherwise blender may crash if memory gets shuffled (I think)
+    camera_prep.camera = cast(bpy.types.Camera, getattr(
+        camera_prep, 'camera', util.add_camera(lens_length=50.0)))
 
-    # Stupid trick -- have it do the camera_view_to_selected with  a slightly
-    # zoomed lens, then zoom it out to what we really want to be at, and we
-    # get a little buffer on the edges of the image
-    camera = util.add_camera(lens_length=52.0)
+    camera = camera_prep.camera
 
-    cameraprep(camera, args.cameraloc, args.camerarot)
-
-    camera.data.lens = 50.0
-
-    # FIXME: Should this be configurable?
     camera.data.clip_end = 100000
-
-    # Black presumably lets us see everything without any external light/color,
-    # though we might want to use medium grey?
-    # util.build_background(bpy.context.scene.world, rgba=(0.0, 0.0, 0.0, 1.0))
-    util.build_background(bpy.context.scene.world, bg_rgb=(
-        0.0, 0.0, 0.0, 1.0), light_rgb=(1.0, 1.0, 1.0, 1.0), light_strength=1.0)
+    bpy.ops.object.select_all(action='SELECT')
+    camera_reset(camera)
+    camera_set_position(camera, cameraloc, camerarot)
 
     # find a better way to do this, since this is a silly return value
     return camera
 
 
 def dorender(args):
-    camera = sceneprep(args)
+    """Render our test image(s) for this test, based on cli arguments"""
+
     # set a nonzero frame so that animated UVs that aren't animating will
     # get caught
     bpy.context.scene.frame_set(50)
 
-    # util.set_cycles_renderer(bpy.context.scene, camera, num_samples=16,
-    #                          use_denoising=False, use_transparent_bg=False)
-    util.set_cycles_renderer(bpy.context.scene)
-    util.set_render_properties(bpy.context.scene, camera, num_samples=16,
-                               use_denoising=False, use_transparent_bg=False)
-    util.set_output_properties(scene=bpy.context.scene,
-                               resolution_percentage=100, output_file_path=args.output)
+    # We can add a sun to our render if we need one, but we don't right now
+    # bpy.ops.object.light_add(type='SUN', radius=1, align='WORLD',
+    #                          location=(0, 0, 0), scale=(1, 1, 1))
 
-    # Update the tile size as one of the last things we do, after everything
-    # is prepped and ready to render.
-    # FIXME: abstract this better
-    bpy.ops.render.autotilesize_set()
+    # Set a background. Black presumably lets us see everything without any
+    # external light/color, though we might want to use medium grey? The
+    # background also emits light (based on light_rgb/light_strength), but
+    # that light isn't visible to the camera
+    util.build_background(
+        bpy.context.scene.world, bg_rgb=(0.0, 0.0, 0.0, 1.0),
+        light_rgb=(1.0, 1.0, 1.0, 1.0), light_strength=1.0)
 
-    tsize = f"{bpy.context.scene.render.tile_x},{bpy.context.scene.render.tile_y}"
-    print(
-        f"Starting render with tile size ({tsize})")
-    bpy.ops.render.render(animation=False, write_still=True,
-                          use_viewport=False)
+    locs = list(locseries_re.finditer(args.cameraloc))
+    rots = list(locseries_re.finditer(args.camerarot))
+
+    # FIXME: Ideally we'd do this before the model was imported, but that
+    # would be even fuglier
+    if len(locs) != len(rots):
+        raise ValueError(f"'loc' and 'rot' lists are of unequal sizes")
+
+    rendercount = 0
+
+    for loc, rot in zip(locs, rots):
+        rendercount += 1
+
+        # FIXME: passing the match objects is FUGLY
+        camera = camera_prep(args, loc, rot)
+
+        # set output filename, varied depending on whether or not this is
+        # a multi-image test
+        if len(locs) == 1:
+            outfile = args.output
+        else:
+            outfile = args.output % (rendercount)
+
+        # Make sure our renderer is set up appropriately
+        util.set_cycles_renderer(bpy.context.scene)
+        util.set_render_properties(bpy.context.scene, camera, num_samples=16,
+                                   use_denoising=False, use_transparent_bg=False)
+        util.set_output_properties(scene=bpy.context.scene,
+                                   resolution_percentage=100, output_file_path=outfile)
+
+        # Update the tile size as one of the last things we do, after everything
+        # is prepped and ready to render.
+        # FIXME: can we abstract this better?
+        bpy.ops.render.autotilesize_set()
+        tsize = f"{bpy.context.scene.render.tile_x},{bpy.context.scene.render.tile_y}"
+
+        # Do the actual render
+        print(
+            f"Starting render #{rendercount} with tile size ({tsize})")
+        start_time = now()
+        bpy.ops.render.render(animation=False, write_still=True,
+                              use_viewport=False)
+        render_time = now() - start_time
+        print(f"Render complete in {render_time:.02f}s")
 
 
 def parse_arguments(args):
@@ -211,27 +277,12 @@ def parse_arguments(args):
 
 
 def main(argv):
-    # world = bpy.context.scene.world
-    # world.use_nodes = True
-    # node_tree = world.node_tree
-
-    # mix_node = node_tree.nodes.new(type="ShaderNodeMixShader")
-    # import inspect
-
-    # for i in inspect.getmembers(mix_node):
-    #     if not i[0].startswith('_'):
-    #         # Ignores methods
-    #         if not inspect.ismethod(i[1]):
-    #             print(i)
-    # sys.exit(0)
-
-    # try:
     if (("--" in argv) == False):
         print("Usage: blender --factory-startup --background --python thisfile.py "
               "-- -o output.png input.obj")
         sys.exit(1)
 
-    # chop argv down to just our arguments
+    # chop argv down to just our arguments (and not blender's)
     args_start = argv.index("--") + 1
     argv = argv[args_start:]
 
@@ -252,13 +303,11 @@ def main(argv):
     util.load_wowobj(args.file)
     print("COMPLETED WOWBJECT IMPORT SUCCESSFULLY")
 
-    print("STARTING WOWBJECT RENDER")
+    print("STARTING WOWBJECT RENDER(S)")
     dorender(args)
-    print("COMPLETED WOWBJECT RENDER SUCCESSFULLY")
-    # except:
-    #     print("Exception caught")
-    #     sys.exit(2)
+    print("COMPLETED WOWBJECT RENDER(S) SUCCESSFULLY")
 
+    # exit unless we've been explicitly asked not to (for testing)
     if not args.noexit:
         sys.exit(0)
 


### PR DESCRIPTION
Specify a camera location & rotation on an otherwise blank line to create a
second (or third, or...) test image from the imported model on the previous
line.

Will probably get rewritten at some point.